### PR TITLE
Set Migrate Tools to 4.1

### DIFF
--- a/.circleci/tests/setup-d8-repo.sh
+++ b/.circleci/tests/setup-d8-repo.sh
@@ -9,7 +9,7 @@ composer config repositories.drupal composer https://packages.drupal.org/8
 
 # Bring in Migrate-related contrib modules.
 composer require drupal/migrate_plus:~4
-composer require drupal/migrate_tools:~4.1
+composer require drupal/migrate_tools:4.1
 composer require drupal/migrate_upgrade:3-rc4
 # Make sure submodules are not committed.
 rm -rf modules/migrate_plus/.git/

--- a/.circleci/tests/setup-d8-repo.sh
+++ b/.circleci/tests/setup-d8-repo.sh
@@ -9,7 +9,7 @@ composer config repositories.drupal composer https://packages.drupal.org/8
 
 # Bring in Migrate-related contrib modules.
 composer require drupal/migrate_plus:~4
-composer require drupal/migrate_tools:~4
+composer require drupal/migrate_tools:~4.1
 composer require drupal/migrate_upgrade:3-rc4
 # Make sure submodules are not committed.
 rm -rf modules/migrate_plus/.git/


### PR DESCRIPTION
I think the release of Migrate Tools 4.3 broke CI https://www.drupal.org/node/3073748